### PR TITLE
Added "slow" typing animation with config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ By default, responses are printed to the screen instantly.
 To enable a fun "slow" typing animation, use:
 
 ```yaml
-slow: true
+slow_typing_effect: True
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ prompt: 'me: '
 ```
 
 
+#### Slow Typing Animation
+
+By default, responses are printed to the screen instantly.
+
+To enable a fun "slow" typing animation, use:
+
+```yaml
+slow: true
+```
+
+
 ## Dependencies
 
 Please have a look at [requirements.txt](./requirements.txt).

--- a/README.md
+++ b/README.md
@@ -140,12 +140,15 @@ So don't hesitate to [help support the hosting fees](https://aidungeon.io/) to k
 Jordan Besly [@p3r7](https://github.com/p3r7) ([blog](https://www.eigenbahn.com/)).
 
 
-## Contributors
+## Contributors & acknowledgements
 
  Major contributions:
  - Idan Gur [@idangur](https://github.com/idangur): OOP rewrite of game logic
  - Alberto Oporto Ames [@otreblan](https://github.com/otreblan): packaging, submission to AUR
+ - [@jgb95](https://github.com/jgb95): slow typing effect
 
  Minor contributions:
  - Robert Davis [@bdavs](https://github.com/bdavs): pip requirements
  - [@Jezza](https://github.com/Jezza): suggested login using creds
+
+Code for slow typing effect inspired by [this message](https://mail.python.org/pipermail/tutor/2003-November/026645.html) from [Magnus Lycka](https://github.com/magnus-lycka) on the [Python Tutor mailing list](https://mail.python.org/mailman/listinfo/tutor).

--- a/ai_dungeon_cli/__init__.py
+++ b/ai_dungeon_cli/__init__.py
@@ -44,7 +44,6 @@ def exists(cfg: Dict[str, str], key: str) -> str:
 # UTILS: TERMINAL
 
 # allow unbuffered output for slow typing effect
-# from: https://mail.python.org/pipermail/tutor/2003-November/026645.html
 class Unbuffered(object):
    def __init__(self, stream):
        self.stream = stream

--- a/ai_dungeon_cli/__init__.py
+++ b/ai_dungeon_cli/__init__.py
@@ -97,6 +97,11 @@ def set_print_handler(method: Callable[[str], None]):
     print_handler = method
 
 
+def set_story_print_handler(method: Callable[[str], None]):
+    global story_print_handler
+    story_print_handler = method
+
+
 def get_user_input_term(prompt: str = '') -> str:
     user_input = input(prompt)
     print()
@@ -108,7 +113,7 @@ def print_output_term(text: str):
     print()
 
 
-def print_slow_term(text: str):
+def print_output_term_slow_effect(text: str):
     for line in textwrap.wrap(text, terminal_width):
         for letter in line:
             print(letter, end='')
@@ -116,8 +121,10 @@ def print_slow_term(text: str):
         print()
     print()
 
+
 input_handler = get_user_input_term
 print_handler = print_output_term
+story_print_handler = print_output_term
 
 
 # -------------------------------------------------------------------------
@@ -127,7 +134,6 @@ class AiDungeon:
     def __init__(self):
 
         # Variables initialization
-        self.slow: bool = False
         self.prompt: str = "> "
         self.auth_token: str = None
         self.email: str = None
@@ -177,8 +183,8 @@ class AiDungeon:
             )
             raise FailedConfiguration
 
-        if exists(cfg, "slow"):
-            self.slow = cfg["slow"]
+        if exists(cfg, "slow_typing_effect"):
+            set_story_print_handler(print_output_term_slow_effect)
         if exists(cfg, "prompt"):
             self.prompt = cfg["prompt"]
         if exists(cfg, "auth_token"):
@@ -308,13 +314,7 @@ class AiDungeon:
         self.public_id = story_response["publicId"]
 
         story_pitch = story_response["story"][0]["value"]
-
-        if self.slow:
-            print_handler = print_slow_term
-        
-        print_handler(story_pitch)
-
-        print_handler = print_output_term
+        story_print_handler(story_pitch)
 
     # Function for when the input typed was ordinary
     def process_regular_action(self, user_input: str):
@@ -324,14 +324,9 @@ class AiDungeon:
         )
         r.raise_for_status()
         action_res = r.json()
+
         action_res_str = action_res[self.prompt_iteration]["value"]
-
-        if self.slow:
-            print_handler = print_slow_term
-        
-        print_handler(action_res_str)
-
-        print_handler = print_output_term
+        story_print_handler(action_res_str)
 
     # Function for when /remember is typed
     def process_remember_action(self, user_input: str):


### PR DESCRIPTION
Hello!
On the web version, there is a slow typing animation for the generated responses, but in this cli version, they are printed instantly, all at once. I feel like the animation really adds to the whole "retro" experience, so I went ahead and implemented something like that here.

To enable it, use "slow: true" in the config file (disabled by default).

Note: I am a student programmer (this is actually my first ever pull request!), so I am not sure if this is the best way of doing things. I am open to suggestions, of course. Or if this is something you'd rather not merge, that is fine as well